### PR TITLE
Generate Kratix resource request in go-service template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Since we don't do releases in this repository, we use the date of the
 change to structure the log.
 
+## 2024-09-03
+
+### Changes
+
+- Generate kratix resource request from `go-service` template.
+
 ## 2024-08-27
 
 ### Changes

--- a/templates/go-service/steps/fetch-template.yaml
+++ b/templates/go-service/steps/fetch-template.yaml
@@ -5,8 +5,8 @@ input:
   url: https://github.com/giantswarm/backstage-catalogs/blob/main/templates/go-service/template
   values:
     project:
-      name: ${{ parameters.name }}
-      description: ${{ parameters.description }}
+      name: ${{ parameters.name | dump }}
+      description: ${{ parameters.description | dump }}
       owner: ${{ parameters.owner | parseEntityRef | pick('name') }}
     projectRepository:
       owner: ${{ parameters.projectRepoOwner }}

--- a/templates/go-service/template/kratix/githubapp.yaml
+++ b/templates/go-service/template/kratix/githubapp.yaml
@@ -1,0 +1,49 @@
+apiVersion: promise.platform.giantswarm.io/v1beta1
+kind: githubapp
+metadata:
+  name: ${{ values.project.name }}
+  namespace: org-demotech
+spec:
+  githubRepo:
+    name: ${{ values.project.name }}
+    spec:
+      repository:
+        name: ${{ values.project.name }}
+        owner: DemoTechInc
+        description: ${{ values.project.description }}
+        templateSource: giantswarm/devplatform-template-go-service
+        visibility: private
+      registryInfoConfigMapRef:
+        name: github-oci-registry-info
+      githubTokenSecretRef:
+        name: dev-platform-gh-access
+  appDeployment:
+    name: ${{ values.project.name }}
+    spec:
+      interval: 1m
+      version: '>=0.1.0'
+      database:
+        engine: aurora-postgresql
+        providerConfigRef:
+          name: demotech-rcc-postgresql-provider-config
+        eso:
+          clusterSsaField: demotech_rcc
+          tenantCluster:
+            apiServerEndpoint: demotech-rds-apiserver-852993111.eu-central-1.elb.amazonaws.com
+            clusterName: demotech-rds
+            enabled: true
+      kubeConfig:
+        secretRef:
+          name: demotech-rds-kubeconfig
+      suspend: false
+      timeout: 3m
+      values:
+        ingress:
+          enabled: false
+        autoscaling:
+          enabled: false
+        pdb:
+          enabled: false
+        monitoring:
+          serviceMonitor:
+            enabled: false


### PR DESCRIPTION
### What does this PR do?

Generate Kratix resource request from `go-service` template.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3470.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
