### PR TITLE
Update githubapp.yaml in go-project template

### DIFF
--- a/templates/go-service/template/kratix/githubapp.yaml
+++ b/templates/go-service/template/kratix/githubapp.yaml
@@ -8,7 +8,7 @@ spec:
     name: ${{ values.project.name }}
     spec:
       backstageCatalogEntity:
-        owner: ${{ values.project.ownerRef }}
+        owner: ${{ values.project.owner }}
         lifecycle: ${{ values.project.lifecycle }}
       repository:
         name: ${{ values.project.name }}


### PR DESCRIPTION
### What does this PR do?

Temporary changing an owner from full reference to a short form:
`group:default/team-service-engineering` -> `team-service-engineering`
since there is some issue with bash templating on Kratix side.