### PR TITLE
Change `githubTokenSecretRef` in templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Since we don't do releases in this repository, we use the date of the
 change to structure the log.
 
+## 2025-07-01
+
+### Changes
+
+- Change `githubTokenSecretRef` in `go-service` and `python-service` templates.
+
 ## 2025-05-29
 
 ### Changes

--- a/templates/go-service/template/githubapp.yaml
+++ b/templates/go-service/template/githubapp.yaml
@@ -19,7 +19,7 @@ spec:
       registryInfoConfigMapRef:
         name: github-oci-registry-info
       githubTokenSecretRef:
-        name: dev-platform-gh-access
+        name: github-app-secret
   appDeployment:
     name: ${{ values.project.name | dump }}
     spec:

--- a/templates/python-service/template/githubapp.yaml
+++ b/templates/python-service/template/githubapp.yaml
@@ -19,7 +19,7 @@ spec:
       registryInfoConfigMapRef:
         name: github-oci-registry-info
       githubTokenSecretRef:
-        name: dev-platform-gh-access
+        name: github-app-secret
   appDeployment:
     name: ${{ values.project.name | dump }}
     spec:


### PR DESCRIPTION
### What does this PR do?

`githubTokenSecretRef` was changed in `go-service` and `python-service` templates.

- [x] CHANGELOG.md has been updated
