### PR TITLE
Do not run "update-catalogs" on push

### DIFF
--- a/.github/workflows/update-catalogs.yaml
+++ b/.github/workflows/update-catalogs.yaml
@@ -1,12 +1,6 @@
 name: Update catalogs
 
 on:
-  push:
-    branches:
-      - "main"
-    paths:
-      - "catalogs/**"
-      - ".github/workflows/update-catalogs.yaml"
   schedule:
     - cron: "50 5,16 * * MON-FRI"
   workflow_dispatch:


### PR DESCRIPTION
This prevents running the workflow automatically after a PR merge etc.