### PR TITLE
Enable Configure with AI button on app-deployment step 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Configure with AI button on app-deployment step 4.
+
 ## [0.3.1] - 2026-04-20
 
 ### Fixed

--- a/templates/app-deployment/template.yaml
+++ b/templates/app-deployment/template.yaml
@@ -128,6 +128,7 @@ spec:
         configurationDocs:
           chartRefField: chartRef
           chartTagField: chartTag
+        configureWithAi: true
       properties:
         valueSources:
           title: Value sources

--- a/templates/app-deployment/template.yaml
+++ b/templates/app-deployment/template.yaml
@@ -128,7 +128,11 @@ spec:
         configurationDocs:
           chartRefField: chartRef
           chartTagField: chartTag
-        configureWithAi: true
+        configureWithAi:
+          chartRefField: chartRef
+          chartTagField: chartTag
+          installationNameField: installation.installationName
+          clusterNameField: cluster.clusterName
       properties:
         valueSources:
           title: Value sources


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4264

### What does this PR do?

Adds \`configureWithAi: true\` under \`ui:options\` on step 4 (Configuration) of the App Deployment template. This activates the new \"Configure with AI\" button rendered by \`GSStepLayout\`, which opens the AI chat with a starter prompt seeded from the chart, version, installation, and cluster the user picked in earlier steps.

### Any background context you can provide?

The button itself is implemented in the [giantswarm/backstage repository](https://github.com/giantswarm/backstage) — this PR is the catalog-side opt-in. Until the corresponding code lands in a Backstage release, the option is a no-op.

### Do the docs (README or /docs) need to be updated?

- [ ] README.md has been updated
- [ ] /docs has been updated

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)