### PR TITLE
feat: add CRD catalog

### DIFF
--- a/.github/workflows/update-catalogs.yaml
+++ b/.github/workflows/update-catalogs.yaml
@@ -86,7 +86,10 @@ jobs:
             gsoci.azurecr.io \
             --prefix charts/giantswarm/ \
             --output ./catalogs
-          
+
+          backstage-catalog-importer crd \
+            --output ./catalogs
+
           ls -la ./catalogs
 
           echo "looked_for_changes=true" >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CRDs catalog
+
 ## [0.4.0] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ File: [charts.yaml](https://github.com/giantswarm/backstage-catalogs/blob/main/c
 
 The charts catalog consist of charts published to the public OCI registry `oci.azurecr.io` by Giant Swarm, represented as `Component` entities. For each chart, only information on the latest release is included.
 
+### Custom Resource Definitions (CRD)
+
+File: [crds.yaml](https://github.com/giantswarm/backstage-catalogs/blob/main/catalogs/crds.yaml)
+
+This catalog provides API entities representing Kubernetes CRDs maintained or used by Giant Swarm.
+
 ### Groups
 
 File: [groups.yaml](https://github.com/giantswarm/backstage-catalogs/blob/main/catalogs/groups.yaml)
@@ -44,6 +50,11 @@ catalog:
       rules:
         allow:
           - Component
+    - type: url
+      target: https://github.com/giantswarm/backstage-catalogs/blob/main/catalogs/crds.yaml
+      rules:
+        allow:
+          - API
     - type: url
       target: https://github.com/giantswarm/backstage-catalogs/blob/main/catalogs/groups.yaml
       rules:


### PR DESCRIPTION
Note: `/catalogs/**.yaml` content should be generated automatically and not be modified manually.

Also note that in this repository we are not creating releases. Customers are encouraged to use the `main` branch and will receive any changes immediately.

### What does this PR do?

Adds generation of a `crds.yaml` catalog file, providing api entities representing Kubernetes CRDs.

### Any background context you can provide?

- https://github.com/giantswarm/roadmap/issues/4200

### Do the docs (README or /docs) need to be updated?

- [x] README.md has been updated
- [ ] /docs has been updated

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
