### PR TITLE
fix: install backstage-catalog-importer from uncompressed release asset

### DIFF
--- a/.github/workflows/update-catalogs.yaml
+++ b/.github/workflows/update-catalogs.yaml
@@ -72,6 +72,9 @@ jobs:
           binary: backstage-catalog-importer
           # renovate: datasource=github-releases depName=giantswarm/backstage-catalog-importer versioning=loose
           version: 0.29.1
+          # Since v0.29.1 the release asset is an uncompressed binary. The URL has no
+          # file extension, so install-binary-action skips unarchiving and installs it directly.
+          download_url: https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-linux-amd64
           smoke_test: ${binary} --help
 
       - name: Execute backstage-catalog-importer


### PR DESCRIPTION
## What

Sets a custom `download_url` for the `install-backstage-catalog-importer` step in `update-catalogs.yaml`.

## Why

Since `backstage-catalog-importer` v0.29.1, the release asset is an **uncompressed binary** (`backstage-catalog-importer-linux-amd64`) instead of a `.tar.gz` archive. The default `download_url` of `install-binary-action` points at a `.tar.gz` file, so the install step fails.

## How

`install-binary-action` treats a `download_url` with no file extension as a raw binary: it skips unarchiving, renames the file to the `binary` input value (`backstage-catalog-importer`), `chmod +x`'s it, and adds it to `PATH`. So the subsequent steps that call `backstage-catalog-importer` continue to work unchanged.

```yaml
download_url: https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-linux-amd64
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)