### PR TITLE
ci: generate groups.yaml via the new groups subcommand

### DIFF
--- a/.github/workflows/update-catalogs.yaml
+++ b/.github/workflows/update-catalogs.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           binary: backstage-catalog-importer
           # renovate: datasource=github-releases depName=giantswarm/backstage-catalog-importer versioning=loose
-          version: 0.29.9
+          version: 0.30.0
           # Since v0.29.1 the release asset is an uncompressed binary. The URL has no
           # file extension, so install-binary-action skips unarchiving and installs it directly.
           download_url: https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-linux-amd64
@@ -88,6 +88,10 @@ jobs:
           backstage-catalog-importer charts \
             gsoci.azurecr.io \
             --prefix charts/giantswarm/ \
+            --output ./catalogs
+
+          # Groups (GitHub teams)
+          backstage-catalog-importer groups \
             --output ./catalogs
 
           # CRDs


### PR DESCRIPTION
### What does this PR do?

Restores updating of [`catalogs/groups.yaml`](https://github.com/giantswarm/backstage-catalogs/blob/main/catalogs/groups.yaml) by adding a `backstage-catalog-importer groups` step to the `update-catalogs` workflow, and bumps the importer from `0.29.9` to `0.30.0` (the release that introduces the `groups` subcommand).

### What is the effect of this change to users?

`groups.yaml` will be regenerated on each scheduled run again. It had been stale since the `appcatalogs` subcommand (which used to produce it) was removed.

### Any background context you can provide?

Resolves giantswarm/giantswarm#36085. The `groups` subcommand was added in giantswarm/backstage-catalog-importer#542 and released in v0.30.0.

### What is needed from the reviewers?

Confirm the `groups` step belongs in this workflow and that `TAYLORBOT_GITHUB_ACTION` has GitHub teams read access (it already drives the other importer steps).