### PR TITLE
ci: restrict groups export to an explicit team allowlist

### DIFF
--- a/.github/workflows/update-catalogs.yaml
+++ b/.github/workflows/update-catalogs.yaml
@@ -91,11 +91,10 @@ jobs:
             --output ./catalogs
 
           # Groups (GitHub teams)
-          # Only export the specific teams that own entities in this catalog.
-          # An explicit allowlist (plus the employees parent guard) avoids
-          # exposing unrelated team names.
+          # Export the product teams via an explicit allowlist (plus the
+          # employees parent guard) so unrelated team names are not exposed.
           backstage-catalog-importer groups \
-            --teams team-atlas,team-honeybadger,team-shield \
+            --teams team-atlas,team-bumblebee,team-cabbage,team-honeybadger,team-nifflers,team-planeteers,team-rainmakers,team-shield,team-team,team-tenet,team-tinkerers,team-up \
             --parent employees \
             --output ./catalogs
 

--- a/.github/workflows/update-catalogs.yaml
+++ b/.github/workflows/update-catalogs.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           binary: backstage-catalog-importer
           # renovate: datasource=github-releases depName=giantswarm/backstage-catalog-importer versioning=loose
-          version: 0.30.0
+          version: 0.31.0
           # Since v0.29.1 the release asset is an uncompressed binary. The URL has no
           # file extension, so install-binary-action skips unarchiving and installs it directly.
           download_url: https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-linux-amd64
@@ -91,7 +91,12 @@ jobs:
             --output ./catalogs
 
           # Groups (GitHub teams)
+          # Only export the specific teams that own entities in this catalog.
+          # An explicit allowlist (plus the employees parent guard) avoids
+          # exposing unrelated team names.
           backstage-catalog-importer groups \
+            --teams team-atlas,team-honeybadger,team-shield \
+            --parent employees \
             --output ./catalogs
 
           # CRDs


### PR DESCRIPTION
### What does this PR do?

Bumps `backstage-catalog-importer` from `0.30.0` to `0.31.0` and passes the new `groups` filtering flags:

- `--teams team-atlas,team-honeybadger,team-shield` — the teams that own entities in this catalog.
- `--parent employees` — guard so only teams under `employees` are eligible.

v0.31.0 makes a filter flag mandatory for `groups`, so this is also required for the workflow to keep working.

### What is the effect of this change to users?

`groups.yaml` will contain only the teams referenced as owners in this catalog, instead of every GitHub team.

### Any background context you can provide?

Follow-up to #615. Importer change: giantswarm/backstage-catalog-importer#544 (released as v0.31.0).

If a future chart introduces a new owning team, add its slug to the `--teams` list.

### What is needed from the reviewers?

Confirm the allowlist matches the teams that own entities here.