### PR TITLE
ci: omit namespace from exported groups

### DIFF
--- a/.github/workflows/update-catalogs.yaml
+++ b/.github/workflows/update-catalogs.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           binary: backstage-catalog-importer
           # renovate: datasource=github-releases depName=giantswarm/backstage-catalog-importer versioning=loose
-          version: 0.31.0
+          version: 0.33.0
           # Since v0.29.1 the release asset is an uncompressed binary. The URL has no
           # file extension, so install-binary-action skips unarchiving and installs it directly.
           download_url: https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-linux-amd64
@@ -96,6 +96,7 @@ jobs:
           backstage-catalog-importer groups \
             --teams team-atlas,team-bumblebee,team-cabbage,team-honeybadger,team-nifflers,team-planeteers,team-rainmakers,team-shield,team-team,team-tenet,team-tinkerers,team-up \
             --parent employees \
+            --namespace "" \
             --output ./catalogs
 
           # CRDs


### PR DESCRIPTION
### What does this PR do?

Bumps `backstage-catalog-importer` to `v0.33.0` and adds `--namespace ""` to the `groups` step so the exported group entities are written without a `namespace` field.

### What is the effect of this change to users?

`groups.yaml` entities no longer carry a `namespace: default` line. Owner references (`group:default/...`) still resolve, since Backstage treats an absent namespace as `default`.

### Any background context you can provide?

Follow-up to #618. Importer change: giantswarm/backstage-catalog-importer#545 (released as v0.33.0).

### What is needed from the reviewers?

Confirm the omitted namespace is desired for this catalog.