### PR TITLE
feat: add agent-deployment scaffolder template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CRDs catalog
+- Add `agent-deployment` template, applying a composed agent manifest (OCIRepository + HelmRelease) via `kube:apply`. Used by the Agent Platform create flow (`/agents/new`); tagged `hidden`.
 
 ### Removed
 

--- a/templates/agent-deployment/template.yaml
+++ b/templates/agent-deployment/template.yaml
@@ -1,0 +1,66 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: agent-deployment
+  title: Agent deployment
+  description: >-
+    Applies a composed agent manifest (OCIRepository + HelmRelease) directly to
+    an installation via kube:apply. Driven by the Agent Platform create flow
+    (/agents/new) — not meant to be run standalone from the scaffolder.
+  # 'hidden' keeps it out of the /create template list (see the GS scaffolder
+  # list override, which filters entities tagged 'hidden').
+  tags:
+    - hidden
+spec:
+  owner: group:team-bumblebee
+  type: resource
+  parameters:
+    - title: Manifest
+      required:
+        - manifest
+        - clusterName
+      properties:
+        manifest:
+          title: Manifest
+          type: string
+          description: The multi-document YAML manifest to apply.
+        clusterName:
+          title: Installation
+          type: string
+          description: Installation / management cluster to apply the manifest to.
+        oidcTokenInstallation:
+          title: OIDC token installation
+          type: string
+          description: >-
+            Installation whose backend the task is routed to (read by the GS
+            scaffolder client).
+        releaseName:
+          title: Release name
+          type: string
+          description: HelmRelease name, used only to build the result link.
+        namespace:
+          title: Namespace
+          type: string
+          description: Namespace the resources land in, used only for the result link.
+  steps:
+    - id: apply
+      name: Apply to installation
+      action: kube:apply
+      input:
+        # 'namespaced' only affects the action's log message; the underlying
+        # KubernetesObjectApi resolves each document's scope on its own.
+        namespaced: true
+        clusterName: ${{ parameters.clusterName }}
+        token: ${{ secrets.USER_OIDC_TOKEN }}
+        manifest: ${{ parameters.manifest }}
+  output:
+    links:
+      - title: Go to the deployment
+        if: ${{ parameters.releaseName and parameters.namespace }}
+        url: /deployments/${{ parameters.clusterName }}/helmrelease/${{ parameters.namespace }}/${{ parameters.releaseName }}
+    text:
+      - title: Applied manifest
+        content: |
+          ```yaml
+          ${{ parameters.manifest }}
+          ```


### PR DESCRIPTION
Adds the `agent-deployment` scaffolder template used by the Agent Platform create flow (giantswarm/backstage#1897).

The template is a thin wrapper around the `kube:apply` action: the `/agents/new` review page composes a multi-document manifest (Flux `OCIRepository` + `HelmRelease`) and this template applies it directly to the selected installation with the caller's OIDC token. It takes the manifest as a parameter — no `fetch:template` skeleton — and is tagged `hidden` so it stays out of the `/create` template list (the GS scaffolder list override filters `hidden` entities).

Once released, the devportal's `catalog.locations` will pin this template at the new tag (follow-up in the management-clusters config, alongside enabling the page).
