### PR TITLE
feat: link to agents list from agent-deployment result page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add a "Go to the agents list" link to the `agent-deployment` template's result page, shown before "Go to the deployment".
+
 ## [0.5.0] - 2026-07-14
 
 ### Added

--- a/templates/agent-deployment/template.yaml
+++ b/templates/agent-deployment/template.yaml
@@ -55,6 +55,8 @@ spec:
         manifest: ${{ parameters.manifest }}
   output:
     links:
+      - title: Go to the agents list
+        url: /agent-platform/agents
       - title: Go to the deployment
         if: ${{ parameters.releaseName and parameters.namespace }}
         url: /deployments/${{ parameters.clusterName }}/helmrelease/${{ parameters.namespace }}/${{ parameters.releaseName }}


### PR DESCRIPTION
### What does this PR do?

Adds a "Go to the agents list" link to the `agent-deployment` scaffolder template's result page, shown **before** the existing "Go to the deployment" link.

After creating an agent through the Agent Platform flow, the user lands on the scaffolder Task page. It previously offered only "Go to the deployment"; this adds a link back to the agents list (`/agent-platform/agents`). The scaffolder renders `output.links` in array order, so the new entry is placed first. No `if:` guard is needed — the agents list is always reachable.

### Any background context you can provide?

Follow-up UX improvement to the `agent-deployment` template added in 0.5.0.

### Do the docs (README or /docs) need to be updated?

- [ ] README.md has been updated
- [ ] /docs has been updated

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
